### PR TITLE
question: don't escape the Markdown

### DIFF
--- a/app/views/evaluations/question.html.haml
+++ b/app/views/evaluations/question.html.haml
@@ -5,7 +5,7 @@
 .question-simple
   .question-description
     :markdown
-      #{h(@question.description)}
+      #{@question.description}
 
   - if @question.resources.present?
     .question-resources.fr-mb-3w

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,39 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "84f8ae78d8b6a58db44e2b0867d17c8f71c33cc94ad61d873e4edc0d79a23041",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped model attribute",
+      "file": "app/views/evaluations/question.html.haml",
+      "line": 8,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "(current_user.active_startups.find_by(:ghid => params[\"startup_ghid\"]).evaluation or Evaluation.from_latest_standards.tap do\n e.update!(:startup => current_user.active_startups.find_by(:ghid => params[\"startup_ghid\"]))\n end).questions.find do\n (q.id == params[:question])\n end.description",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "EvaluationsController",
+          "method": "question",
+          "line": 30,
+          "file": "app/controllers/evaluations_controller.rb",
+          "rendered": {
+            "name": "evaluations/question",
+            "file": "app/views/evaluations/question.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "evaluations/question"
+      },
+      "user_input": "current_user.active_startups.find_by(:ghid => params[\"startup_ghid\"])",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": "We peer-review all standards"
+    }
+  ],
+  "brakeman_version": "7.1.0"
+}


### PR DESCRIPTION
">" is used for blockquotes, so don't interpolate. The security risk is unimportant since we peer-review all of the standards.

c.f https://github.com/betagouv/standards/pull/180